### PR TITLE
Use foldProjectContexts

### DIFF
--- a/content/blog/elm-review-insights/index.md
+++ b/content/blog/elm-review-insights/index.md
@@ -131,7 +131,7 @@ rule =
         |> Rule.withModuleContextUsingContextCreator
             { fromModuleToProject = fromModuleToProject
             , fromProjectToModule = Rule.initContextCreator (\_ -> ())
-            , foldProjectContexts = Dict.union
+            , foldProjectContexts = foldProjectContexts
             }
         |> Rule.withDataExtractor dataExtractor
         |> Rule.fromProjectRuleSchema


### PR DESCRIPTION
Alternatively, delete the definition of `foldProjectContexts` on lines 160-167.