### PR TITLE
feat: add dark mode

### DIFF
--- a/src/utils/theme.css
+++ b/src/utils/theme.css
@@ -70,12 +70,12 @@ code[class*='language-'] ::selection {
   text-shadow: none;
   background: hsla(0, 0%, 93%, 0.15);
 }
-
+  
 /* Inline code */
 :not(pre) > code[class*='language-'] {
   border-radius: 0.3em;
-  background: rgba(255, 229, 100, 0.2);
-  color: #1a1a1a;
+  background: var(--bg-code);
+  color: var(--text-code);
   padding: 0.15em 0.2em 0.05em;
   white-space: normal;
 }

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -3,6 +3,24 @@ import Wordpress2016 from 'typography-theme-wordpress-2016'
 
 Wordpress2016.overrideThemeStyles = () => {
   return {
+    'html': {
+      'color-scheme': 'light dark',
+    },
+    '@media (prefers-color-scheme: light)': {
+      ':root': {
+        '--bg-code': 'rgba(255, 229, 100, 0.2)',
+        '--text-code': '#1a1a1a'
+      }
+    },
+    '@media (prefers-color-scheme: dark)': {
+      'body': {
+        'color': 'white'
+      },
+      ':root': {
+        '--bg-code': 'rgba(0, 122, 204, 0.2)',
+        '--text-code': '#d0d0ff'
+      },
+    },
     'a.gatsby-resp-image-link': {
       boxShadow: `none`,
     },


### PR DESCRIPTION
# Summary

There is few caveats here that needs to be decided:

1. Chrome & Safari(15.4+) but Firefox Dev edition is not responding for system appearance mode changes, it's just dark for it.
2. When I changed background to darker, `code` tag parts in internal pages got to have bad contrast, so I took some liberty to change the color there (see screenshots) and preview.
3. Button for manually changing between modes is missing. 
4. Favicon is not color scheme responsive.
5. Internal pages titles are 'too white' almost  

preview: https://deploy-preview-2--jurun.netlify.app/

https://github.com/ultrox/blog-2/assets/3077558/b93e7774-460c-427c-844b-68d524fb2a84

![CleanShot 2023-05-13 at 18 07 21](https://github.com/ultrox/blog-2/assets/3077558/48d5888b-83e0-4cd8-a29c-a33c26bc15b4)
