### PR TITLE
Fix article code block width

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,15 @@ body {
   @apply antialiased text-slate-500 dark:text-slate-400 bg-white dark:bg-slate-900
 }
 
+/* Make <pre> elements not contribute to the width calculation of parents.
+ * Instead, let them be as wide as the parent.
+ * This allows a horizontal scrollbar to appear instead of making the whole
+ * article wider, overflowing its parent, and going offscreen on phones.
+ */
+pre {
+  contain: inline-size;
+}
+
 /* Elm Syntax Highlight CSS */
 pre.elmsh {
   padding: 10px;


### PR DESCRIPTION
The code blocks caused the article to be much wider than intended, both on desktop and on phones. On phones, the article became partially offscreen, making it difficult to read.